### PR TITLE
0.14.0

### DIFF
--- a/client/src/components/CurrentProjects.jsx
+++ b/client/src/components/CurrentProjects.jsx
@@ -61,7 +61,7 @@ const CurrentProjects = () => {
                 <td className="py-4 px-6">
                   <div className="text-indigo-500">
                     {" "}
-                    <a href={`/-${project._id}`}> {project.title}</a>
+                    <a href={`/project?=${project._id}`}> {project.title}</a>
                   </div>
                   <div className="text-indigo-500">
                     Status: {project.projectstatus}
@@ -86,11 +86,5 @@ const CurrentProjects = () => {
     </>
   );
 };
-
-// const getProjectIdFromUrl = () => {
-//   const url = window.location.href;
-//   const id = url.split('-').pop().trim();
-//   return id;
-// };
 
 export default CurrentProjects;

--- a/client/src/pages/Project.jsx
+++ b/client/src/pages/Project.jsx
@@ -1,14 +1,38 @@
 import CritterContainer from "../components/CritterContainer";
 import ProjectColumn from "../components/ProjectColumn";
+import { useQuery, useMutation } from "@apollo/client";
+
+import { RETURN_PROJECT } from "../utils/query";
+
 
 const Project = () => {
   // TODO: get project by projectId
   // for testing:
+
   const creationDate = new Date("June 1, 2023 23:15:30 UTC");
   const jsonDate = creationDate.toJSON();
+
+  const url = window.location.href;
+  const id = url.split("=").pop().trim();
+
+  console.log(id)
+
+  const { data, loading } = useQuery(RETURN_PROJECT, {
+    variables: { input: id },
+  });
+
+  if (loading) {
+    return <p>Loading...</p>; // Return a loading indicator while data is being fetched
+  }
+
+  if (!data) {
+    return <p>No data found.</p>; // Handle the case when no data is returned
+  }
+
+
   const project = {
-    id: 1,
-    name: "Project A",
+    id: data.returnProject._id,
+    name: data.returnProject.title,
     critterName: "Little Guy",
     createdAt: jsonDate,
   };

--- a/client/src/utils/query.js
+++ b/client/src/utils/query.js
@@ -15,6 +15,16 @@ export const RETURN_USER = gql`
   }
 `;
 
+export const RETURN_PROJECT = gql`
+  query ReturnProject($input: String!) {
+    returnProject(input: $input) {
+        _id
+        projectstatus
+        title
+    }
+  }
+`;
+
 // tasks {
 //   taskstate
 //   taskbody

--- a/server/graphql/resolvers.js
+++ b/server/graphql/resolvers.js
@@ -17,6 +17,20 @@ const resolvers = {
         throw new AuthenticationError("mustbeloggedin");
       }
     },
+
+    returnProject: async (_, args, context) => {
+      if (context) {
+        const currentUser = await User.findOne({ _id: context._id }).select(
+          "-__v -password"
+        );
+        const selectedProject = currentUser.projects.find(
+          (project) => project._id.toString() === args.input
+        );
+        return selectedProject;
+      } else {
+        throw new AuthenticationError("mustbeloggedin");
+      }
+    },
   },
 
   Mutation: {
@@ -52,9 +66,6 @@ const resolvers = {
       return addProjectToUser;
     },
 
-
-
-    
     delProject: async (_, args, context) => {
       if (!context) {
         throw new AuthenticationError("Please log in first!");
@@ -65,9 +76,6 @@ const resolvers = {
       );
       return removeProjectFromUser;
     },
-
-
-
 
     createTask: async (_, { projectId, tasks }, context) => {
       if (!projectId) {

--- a/server/graphql/typeDefs.js
+++ b/server/graphql/typeDefs.js
@@ -46,6 +46,7 @@ const typeDefs = gql`
 
     type Query { 
         returnUser: User
+        returnProject(input: String!): Project
     }
 
     type Mutation {


### PR DESCRIPTION
CLIENT: updated currentprojects.jsx component to have beeter indentation, updated the way the href and id are put into the url it is now not an endpoint but instead a query string. so that you can hit the /projects endpoint with the id within the url still, updated page/project.jsx to get the window.location.href and split the url based on the = and assign that id to a variable that will be used to pass in as an arguemnt for the return_project query resolver, sucessfully returned data and dynamically rendered project based off of the query string from the url. updated utils/query.js added RETURN_PROJECT GQL snippit to return all wanted data. SERVER: updated typedefs to have the new query method return_project for project.jsx, added new resolver async function to return the projects from the usermodel since the project is a embbeddoc used the .find method inside of the resolver and returned selectedProject variable, to populate with specific data. Conclusion: You can now while logged in, navigate to the dashboard add a project, click on a project and be directed to an instance of the projects.jsx page with dynamically generated data from the id that was input to the url as a querystring, based off the id of which project your clicked.