### PR TITLE
0.17.0

### DIFF
--- a/client/src/components/ProjectColumn.jsx
+++ b/client/src/components/ProjectColumn.jsx
@@ -6,41 +6,48 @@ import {
   PencilIcon,
 } from "@heroicons/react/24/solid";
 
-import { useMutation, useQuery} from "@apollo/client";
-import { CREATE_TASK } from "../utils/mutation";
+import { useQuery } from "@apollo/client";
+import { RETURN_TASKS } from "../utils/query";
 
 const ProjectColumn = ({ title, colNum, projId }) => {
   // TODO: get all tasks where projectId = projId and taskstate = colNum
   // for testing:
+  const url = window.location.href;
+  const id = url.split("=").pop().trim();
 
-  const [createTask] = useMutation(CREATE_TASK)
+  const { data, loading } = useQuery(RETURN_TASKS, {
+    variables: { input: id },
+  });
 
-  
+  if (loading) {
+    return "loading";
+  } 
 
+const task = data.returnTasks
+console.log(task)
 
-  let tasks = [];
-  if (colNum === 2) {
-    tasks = [{ id: 1, taskbody: "Do a thing" }];
-  } else if (colNum === 3) {
-    tasks = [
-      { id: 1, taskbody: "Do another thing" },
-      { id: 2, taskbody: "Do a different thing" },
-      {
-        id: 3,
-        taskbody:
-          "Do a third thing and also the taskbody text is really really really really really long",
-      },
-    ];
-  } else if (colNum === 4) {
-    tasks = [
-      { id: 2, taskbody: "Thing that got did" },
-      {
-        id: 2,
-        taskbody:
-          "Another thing that got did",
-      },
-    ];
-  }
+  // let tasks = []
+  // if (colNum === 2) {
+  //   tasks = [{ id: 1, taskbody: "Do a thing" }];
+  // } else if (colNum === 3) {
+  //   tasks = [
+  //     { id: 1, taskbody: "Do another thing" },
+  //     { id: 2, taskbody: "Do a different thing" },
+  //     {
+  //       id: 3,
+  //       taskbody:
+  //         "Do a third thing and also the taskbody text is really really really really really long",
+  //     },
+  //   ];
+  // } else if (colNum === 4) {
+  //   tasks = [
+  //     { id: 2, taskbody: "Thing that got did" },
+  //     {
+  //       id: 2,
+  //       taskbody: "Another thing that got did",
+  //     },
+  //   ];
+  // }
 
   return (
     <div className="flex flex-col md:w-[276px] md:min-w-[276px] border-4 border-indigo-500 rounded-xl md:overflow-hidden">
@@ -53,9 +60,9 @@ const ProjectColumn = ({ title, colNum, projId }) => {
           {/* render tasks as list items */}
           {/* TODO: pencil edits taskbody (modal should have a delete option) */}
           {/* TODO: left and right arrows decrease or increase taskstate */}
-          {tasks.length ? (
+          {task.length ? (
             <>
-              {tasks.map((task) => (
+              {task.map((task) => (
                 <li className="p-2">
                   <div className="flex items-center justify-between p-1 bg-indigo-200 text-md min-h-[42px] rounded">
                     <p>{task.taskbody}</p>

--- a/client/src/utils/query.js
+++ b/client/src/utils/query.js
@@ -18,11 +18,22 @@ export const RETURN_USER = gql`
 export const RETURN_PROJECT = gql`
   query ReturnProject($input: String!) {
     returnProject(input: $input) {
-        _id
-        projectstatus
-        title
-        critterName
-        createdAt
+      _id
+      projectstatus
+      title
+      critterName
+      createdAt
+    }
+  }
+`;
+
+export const RETURN_TASKS = gql`
+  query returnTasks($input: String!) {
+    returnTasks(input: $input) {
+      _id
+      projectId
+      taskbody
+      taskstate
     }
   }
 `;

--- a/server/graphql/resolvers.js
+++ b/server/graphql/resolvers.js
@@ -31,6 +31,27 @@ const resolvers = {
         throw new AuthenticationError("mustbeloggedin");
       }
     },
+
+    returnTasks: async (_, args, context) => {
+      if (context) {
+        const currentUser = await User.findOne({
+          _id: context._id,
+        }).select("-__v -password");
+        const projectIndex = await currentUser.projects.findIndex(
+          (project) => project._id.toString() === args.input
+        );
+
+        if (projectIndex === -1) {
+          throw new Error("Project not found");
+        }
+
+        const tasks = await currentUser.projects[projectIndex].tasks;
+
+        return tasks;
+      } else {
+        throw new AuthenticationError("mustbeloggedin");
+      }
+    },
   },
 
   Mutation: {

--- a/server/graphql/typeDefs.js
+++ b/server/graphql/typeDefs.js
@@ -52,6 +52,7 @@ const typeDefs = gql`
   type Query {
     returnUser: User
     returnProject(input: String!): Project
+    returnTasks(input: String!): [Task]
   }
 
   type Mutation {


### PR DESCRIPTION
OVERHAUL: SERVER: added typedef for returnTask query, added new resolver function to graphql/resolvers returnTasks, gets current user with context, finds the index of the project by the args.input then returns the task by the users project[index].tasks. CLIENT: added clinet side query to utils/query.js for the RETURN_TASK resolver, updated projectColumn.tsx function component, to use hooks to get data then map over it. CONCLUSION: tasks now dynamically render over the project page.